### PR TITLE
mirage 3.7.0 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ script: bash -ex .travis-opam.sh
 env:
     global:
         - PACKAGE="mirage-xen"
-        - REVDEPS=*
-        - PINS="mirage-runtime:https://github.com/mirage/mirage.git"
     matrix:
+        - OCAML_VERSION=4.08
         - OCAML_VERSION=4.07
         - OCAML_VERSION=4.06
-        - OCAML_VERSION=4.05
-        - OCAML_VERSION=4.04

--- a/lib/dune
+++ b/lib/dune
@@ -2,4 +2,4 @@
  (name oS)
  (public_name mirage-xen)
  (wrapped true)
- (libraries lwt cstruct xen-evtchn xenstore.client shared-memory-ring-lwt mirage-profile logs io-page-xen fmt mirage-xen.bindings))
+ (libraries lwt cstruct xen-evtchn xenstore.client shared-memory-ring-lwt mirage-profile logs io-page-xen fmt mirage-xen.bindings mirage-runtime))

--- a/lib/main.ml
+++ b/lib/main.ml
@@ -44,17 +44,13 @@ let rec call_hooks hooks  =
 
 external look_for_work: unit -> bool = "stub_evtchn_look_for_work"
 
-let err exn =
-  Logs.err (fun m -> m "main: %s\n%s" (Printexc.to_string exn) (Printexc.get_backtrace ())) ;
-  exit 1
-
 (* Execute one iteration and register a callback function *)
 let run t =
   let t = call_hooks enter_hooks <&> t in
   let rec aux () =
     Lwt.wakeup_paused ();
     Time.restart_threads Time.Monotonic.time;
-    match (try Lwt.poll t with exn -> err exn) with
+    match Lwt.poll t with
     | Some () ->
         ()
     | None ->

--- a/lib/main.mli
+++ b/lib/main.mli
@@ -18,3 +18,4 @@ val run : unit Lwt.t -> unit
 val at_enter : (unit -> unit Lwt.t) -> unit
 val at_enter_iter : (unit -> unit) -> unit
 val at_exit_iter  : (unit -> unit) -> unit
+val at_exit : (unit -> unit Lwt.t) -> unit

--- a/lib/main.mli
+++ b/lib/main.mli
@@ -15,7 +15,3 @@
  *)
 
 val run : unit Lwt.t -> unit
-val at_enter : (unit -> unit Lwt.t) -> unit
-val at_enter_iter : (unit -> unit) -> unit
-val at_exit_iter  : (unit -> unit) -> unit
-val at_exit : (unit -> unit Lwt.t) -> unit

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -33,8 +33,13 @@ end
 module Main : sig
 val run : unit Lwt.t -> unit
 val at_enter : (unit -> unit Lwt.t) -> unit
+[@deprecate "This functionality will be removed in MirageOS 4.0. If you need at_enter, please consult the mirageos-devel@lists.xenproject.org mailing list."]
 val at_enter_iter : (unit -> unit) -> unit
+[@deprecate "Use Mirage_runtime.at_enter_iter instead"]
 val at_exit_iter  : (unit -> unit) -> unit
+[@deprecate "Use Mirage_runtime.at_exit_iter instead"]
+val at_exit : (unit -> unit Lwt.t) -> unit
+[@deprecate "Use Mirage_runtime.at_exit instead"]
 end
 
 module MM : sig

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -32,14 +32,6 @@ end
 
 module Main : sig
 val run : unit Lwt.t -> unit
-val at_enter : (unit -> unit Lwt.t) -> unit
-[@deprecate "This functionality will be removed in MirageOS 4.0. If you need at_enter, please consult the mirageos-devel@lists.xenproject.org mailing list."]
-val at_enter_iter : (unit -> unit) -> unit
-[@deprecate "Use Mirage_runtime.at_enter_iter instead"]
-val at_exit_iter  : (unit -> unit) -> unit
-[@deprecate "Use Mirage_runtime.at_exit_iter instead"]
-val at_exit : (unit -> unit Lwt.t) -> unit
-[@deprecate "Use Mirage_runtime.at_exit instead"]
 end
 
 module MM : sig

--- a/lib/oS.mli
+++ b/lib/oS.mli
@@ -50,8 +50,6 @@ end
 end
 module Time : sig
 
-type +'a io = 'a Lwt.t
-
 (** Timeout operations. *)
 
 module Monotonic : sig

--- a/lib/time.ml
+++ b/lib/time.ml
@@ -26,8 +26,6 @@
 [@@@warning "-3-9"] (* FIXME Lwt_pqueue *)
 open Lwt
 
-type +'a io = 'a Lwt.t
-
 module Monotonic = struct
   type time_kind = [`Time | `Interval]
   type 'a t = int64 constraint 'a = [< time_kind]

--- a/lib/time.mli
+++ b/lib/time.mli
@@ -14,8 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-type +'a io = 'a Lwt.t
-
 (** Timeout operations. *)
 
 module Monotonic : sig

--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -26,6 +26,7 @@ depends: [
   "mirage-xen-ocaml" {>= "3.3.1"}
   "io-page-xen" {>= "2.0.0"}
   "mirage-xen-minios" {>= "0.7.0"}
+  "mirage-runtime" {>= "3.7.0"}
   "logs"
   "fmt"
 ]

--- a/mirage-xen.opam
+++ b/mirage-xen.opam
@@ -13,7 +13,7 @@ build: [
   [ "env" "OPAM_PKG_CONFIG_PATH=%{prefix}%/lib/pkgconfig" "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "ocaml" {>= "4.04.2"}
+  "ocaml" {>= "4.06.0"}
   "dune"
   "cstruct" {>= "1.0.1"}
   "lwt" {>= "2.4.3"}


### PR DESCRIPTION
with the hooks, and also exit behaviour -- on top of the merge into single package (no `.internals` anymore)